### PR TITLE
修复华为手机在recyclerView中使用 不会自动滚动问题 Update BannerViewPager.java

### DIFF
--- a/bannerview/src/main/java/com/zhpan/bannerview/BannerViewPager.java
+++ b/bannerview/src/main/java/com/zhpan/bannerview/BannerViewPager.java
@@ -71,7 +71,7 @@ public class BannerViewPager<T> extends RelativeLayout implements LifecycleObser
 
   private BannerManager mBannerManager;
 
-  private final Handler mHandler = new Handler();
+  private final Handler mHandler = new Handler(Looper.getMainLooper());
 
   private BaseBannerAdapter<T> mBannerPagerAdapter;
 


### PR DESCRIPTION
修复华为手机在recyclerView中使用 不会自动滚动问题
（华为手机会出现Runnable中run()方法不执行问题）
已验证修复，只有华为手机有这个问题，其他厂商手机没有这个问题。